### PR TITLE
Light bugfix - date checks

### DIFF
--- a/backend/src/projects/project.dto.ts
+++ b/backend/src/projects/project.dto.ts
@@ -7,6 +7,7 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsValidDate } from "./projects.validator";
 
 export class ProjectDto {
   @IsNotEmpty()
@@ -28,6 +29,7 @@ export class ProjectDto {
 
   @IsOptional()
   @IsDate()
+  @IsValidDate("startDate", {message: "Project end date must be greater than the start date."})
   @Type(() => Date)
   @ApiProperty({ example: '2020/07/16' })
   endDate: Date;

--- a/backend/src/projects/projects.validator.ts
+++ b/backend/src/projects/projects.validator.ts
@@ -1,16 +1,13 @@
-import { registerDecorator, ValidationOptions, ValidationArguments } from "class-validator";
-import { ValidOptions } from "./projects.validoptions";
+import {registerDecorator, ValidationOptions, ValidationArguments} from "class-validator";
 
-export function IsValidDate(property: string, ValidOptions?: ValidationOptions) {
-    errorHttpStatusCode: 442;
-
-    return function (object: Object, propertyName: string) {
+export function IsValidDate(property: string, validationOptions?: ValidationOptions) {
+   return function (object: Object, propertyName: string) {
         registerDecorator({
             name: "IsValidDate",
             target: object.constructor,
             propertyName: propertyName,
             constraints: [property],
-            options: ValidOptions,
+            options: validationOptions,
             validator: {
                 validate(value: any, args: ValidationArguments) {
                     const [relatedPropertyName] = args.constraints;

--- a/backend/src/projects/projects.validator.ts
+++ b/backend/src/projects/projects.validator.ts
@@ -1,0 +1,20 @@
+import {registerDecorator, ValidationOptions, ValidationArguments} from "class-validator";
+
+export function IsValidDate(property: string, validationOptions?: ValidationOptions) {
+   return function (object: Object, propertyName: string) {
+        registerDecorator({
+            name: "IsValidDate",
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [property],
+            options: validationOptions,
+            validator: {
+                validate(value: any, args: ValidationArguments) {
+                    const [relatedPropertyName] = args.constraints;
+                    const relatedValue = args.object[relatedPropertyName];
+                    return value > relatedValue;
+                }
+            }
+        });
+   };
+}

--- a/backend/src/projects/projects.validator.ts
+++ b/backend/src/projects/projects.validator.ts
@@ -1,13 +1,16 @@
-import {registerDecorator, ValidationOptions, ValidationArguments} from "class-validator";
+import { registerDecorator, ValidationOptions, ValidationArguments } from "class-validator";
+import { ValidOptions } from "./projects.validoptions";
 
-export function IsValidDate(property: string, validationOptions?: ValidationOptions) {
-   return function (object: Object, propertyName: string) {
+export function IsValidDate(property: string, ValidOptions?: ValidationOptions) {
+    errorHttpStatusCode: 442;
+
+    return function (object: Object, propertyName: string) {
         registerDecorator({
             name: "IsValidDate",
             target: object.constructor,
             propertyName: propertyName,
             constraints: [property],
-            options: validationOptions,
+            options: ValidOptions,
             validator: {
                 validate(value: any, args: ValidationArguments) {
                     const [relatedPropertyName] = args.constraints;

--- a/backend/src/projects/projects.validoptions.ts
+++ b/backend/src/projects/projects.validoptions.ts
@@ -1,0 +1,8 @@
+import { ValidationError, ValidatorOptions } from "class-validator";
+
+export interface ValidOptions extends ValidatorOptions {
+    transform?: boolean;
+    disableErrorMessages?: boolean;
+    errorHttpStatusCode: 442;
+    exceptionFactory?: (errors: ValidationError[]) => any;
+}

--- a/backend/src/projects/projects.validoptions.ts
+++ b/backend/src/projects/projects.validoptions.ts
@@ -1,8 +1,0 @@
-import { ValidationError, ValidatorOptions } from "class-validator";
-
-export interface ValidOptions extends ValidatorOptions {
-    transform?: boolean;
-    disableErrorMessages?: boolean;
-    errorHttpStatusCode: 442;
-    exceptionFactory?: (errors: ValidationError[]) => any;
-}


### PR DESCRIPTION
This is a simple bugfix to limit dates when making a post request.
currently, `endDate` must be greater than `startDate` or it'll throw a 400 Bad request error.

It may be worth thinking about whether or not there should be minimum date range for the project
(i.e. should one-day projects be allowed? should projects have a minimum range of a week?)