### PR TITLE
Added auth/signup route

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -12,8 +12,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
 import { JwtPayload } from './interfaces/jwt-payload.interface';
 import { User } from '../users/user.entity';
+import { UserDto } from '../users/user.dto';
 
 class AuthResponse {
   @ApiProperty()
@@ -26,7 +28,10 @@ class AuthResponse {
 @Controller('auth')
 @ApiTags('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private usersService: UsersService,
+  ) {}
 
   @Post('login')
   @ApiOperation({ summary: 'Logs in as a user' })
@@ -52,6 +57,40 @@ export class AuthController {
 
     return {
       accessToken: this.authService.createToken(payload),
+      user,
+    };
+  }
+
+  @Post('signup')
+  @ApiOperation({ summary: "Creates a user and returns it's access token" })
+  @ApiResponse({
+    status: 201,
+    description: 'Sends the JSON Web Token and the corresponding user',
+    type: AuthResponse,
+  })
+  @ApiResponse({
+    status: 401,
+    description:
+      'Unauthorized access. The email and password combination do not match or do not exist.',
+  })
+  async signup(@Body() userDto: UserDto): Promise<AuthResponse> {
+    await this.usersService.create(userDto);
+    const credentials: JwtPayload = {
+      email: userDto.email,
+      password: userDto.password,
+    };
+
+    const user = await this.authService.validateUser(credentials);
+
+    if (!user) {
+      throw new HttpException(
+        `Unauthorized access. The email and password combination do not match or do not exist.`,
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    return {
+      accessToken: this.authService.createToken(credentials),
       user,
     };
   }


### PR DESCRIPTION
Added a new route that creates a `User` and returns the JWT associated with the account. 

This route accomplished the same work as making a POST at `/users` to create a user and then making another post at `/auth/login`, but in a single http request.