### PR TITLE
Repository file cleanup 🧼

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Removes a file present on the repo's root. The file was added by mistake in #44 