### PR TITLE
Feature/project likes

### DIFF
--- a/backend/src/projects/project.entity.ts
+++ b/backend/src/projects/project.entity.ts
@@ -72,6 +72,7 @@ export class Project {
    * Calculated field (value: likers.length)
    */
   @Column()
+  @ApiProperty({ example: 6 })
   likeCount: number;
 
   constructor(

--- a/backend/src/projects/project.entity.ts
+++ b/backend/src/projects/project.entity.ts
@@ -5,9 +5,12 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   ManyToOne,
+  ManyToMany,
+  JoinTable,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Organization } from '../organizations/organization.entity';
+import { User } from '../users/user.entity';
 
 @Entity()
 export class Project {
@@ -55,6 +58,22 @@ export class Project {
   })
   organization: Organization;
 
+  @ApiProperty({
+    type: () => User,
+  })
+  @ManyToMany(
+    () => User,
+    (user: User) => user.likedProjects,
+  )
+  @JoinTable()
+  likers: User[];
+
+  /**
+   * Calculated field (value: likers.length)
+   */
+  @Column()
+  likeCount: number;
+
   constructor(
     id?: number,
     name?: string,
@@ -63,6 +82,7 @@ export class Project {
     endDate?: Date,
     isFeatured?: boolean,
     organization?: Organization,
+    likers?: User[],
   ) {
     this.id = id;
     this.name = name;
@@ -71,5 +91,7 @@ export class Project {
     this.endDate = endDate;
     this.isFeatured = isFeatured;
     this.organization = organization;
+    this.likers = likers;
+    this.likeCount = likers?.length ?? 0;
   }
 }

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -106,6 +106,17 @@ export class ProjectsController {
     return this.projectsService.update(id, newProjectInfo);
   }
 
+  @Post(':id/toggle-like')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Toggle a like of a project' })
+  async toggleLike(
+    @Req() req: { user: User },
+    @Param('id') id: number,
+  ): Promise<Project> {
+    return this.projectsService.toggleLike(id, req.user);
+  }
+
   @Delete(':id')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -109,8 +109,22 @@ export class ProjectsController {
   @Post(':id/toggle-like')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Toggle a like of a project' })
-  async toggleLike(
+  @ApiOperation({ summary: 'Likes or unlikes a project' })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the updated project',
+    type: Project,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized. When the JWT is not provided or invalid',
+  })
+  @ApiResponse({
+    status: 404,
+    description:
+      'Error message saying that no project with the specified id has been found',
+  })
+  toggleLike(
     @Req() req: { user: User },
     @Param('id') id: number,
   ): Promise<Project> {

--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { ProjectDto } from './project.dto';
 import { Project } from './project.entity';
 import { OrganizationsService } from '../organizations/organizations.service';
+import { User } from '../users/user.entity';
 
 @Injectable()
 export class ProjectsService {
@@ -31,7 +32,9 @@ export class ProjectsService {
   }
 
   async findOne(id: number): Promise<Project> {
-    const project = await this.projectsRepository.findOne(id);
+    const project = await this.projectsRepository.findOne(id, {
+      relations: ['likers'],
+    });
 
     if (project === undefined) {
       throw new HttpException(
@@ -49,7 +52,16 @@ export class ProjectsService {
   async findFeatured(isFeatured: boolean): Promise<Project[]> {
     const projects = await this.projectsRepository.find({
       where: { isFeatured },
-      select: ['id', 'description', 'startDate', 'endDate', 'organization', 'isFeatured', 'createdAt', 'updatedAt'],
+      select: [
+        'id',
+        'description',
+        'startDate',
+        'endDate',
+        'organization',
+        'isFeatured',
+        'createdAt',
+        'updatedAt',
+      ],
     });
 
     if (projects === undefined) {
@@ -69,6 +81,23 @@ export class ProjectsService {
     await this.findOne(id); // checks if the project exists
     await this.projectsRepository.update(id, project);
     return this.projectsRepository.findOne(id);
+  }
+
+  async toggleLike(id: number, user: User): Promise<Project> {
+    const project = await this.findOne(id);
+
+    // update the likers array
+    const likerIndex = project.likers.findIndex(liker => liker.id === user.id);
+    if (likerIndex > -1) {
+      project.likers.splice(likerIndex, 1);
+    } else {
+      project.likers.push(user);
+    }
+
+    // update the like count
+    project.likeCount = project.likers.length;
+
+    return this.projectsRepository.save(project);
   }
 
   async remove(id: number): Promise<void> {

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -6,10 +6,12 @@ import {
   UpdateDateColumn,
   OneToOne,
   JoinColumn,
+  ManyToMany,
 } from 'typeorm';
 import { Exclude } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { Organization } from '../organizations/organization.entity';
+import { Project } from '../projects/project.entity';
 
 @Entity()
 export class User {
@@ -50,6 +52,15 @@ export class User {
   )
   @JoinColumn()
   ownedOrganization: Organization;
+
+  @ApiProperty({
+    type: () => Project,
+  })
+  @ManyToMany(
+    () => Project,
+    (project: Project) => project.likers,
+  )
+  likedProjects: Project[];
 
   constructor(
     id?: number,

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -39,7 +39,7 @@ export class UsersService {
 
   async findOne(id: number): Promise<User> {
     const user = await this.usersRepository.findOne(id, {
-      relations: ['ownedOrganization'],
+      relations: ['ownedOrganization', 'likedProjects'],
     });
 
     if (user === undefined) {


### PR DESCRIPTION
# Project Like feature

Added the ability for users to like projects. This PR adds a Many-to-Many relationship between User and Project. New fields have been added in both entities and a new route has been created

## New field in `User`

- `likedProject: Project[]`: a list of the liked project by the user. Only accessible when fetching the user by id

## New fields in `Project`

- `likers: User[]`: a list the users that liked the project. Only accessible when fetching the user by id
- `likeCount: number`: a calculated field updated at each "like update". This field is accessible on all GET routes

## New route

- `/projects/:id/toggle-like` (Auth required): When called, the project will be considered as liked by the user if the user has not liked the project yet. If the user already liked the project, calling this route will unlike the project